### PR TITLE
Improve options save alert

### DIFF
--- a/options.js
+++ b/options.js
@@ -12,7 +12,7 @@ function saveOption() {
   }
   chrome.storage.local.set({ projects: projects }, function () {});
   chrome.storage.local.set({ sids: sids }, function () {});
-  alert("saved", projects, sids);
+  alert(`saved: ${projects.join(', ')}`);
 }
 
 function loadOption() {


### PR DESCRIPTION
## Summary
- improve the alert after saving options to show selected projects

## Testing
- `npm test` *(fails: ENOENT: no such file or directory)*